### PR TITLE
Fix: use a directory separator when combining dirs.

### DIFF
--- a/tg.php
+++ b/tg.php
@@ -8,7 +8,7 @@
  * @web: https://github.com/ktamas77/team-gource
  */
 
-$config = yaml_parse(file_get_contents(__DIR__ . 'tg.conf'));
+$config = yaml_parse(file_get_contents(__DIR__ .DIRECTORY_SEPARATOR .'tg.conf'));
 
 function updateRepo($org, $repo) {
     if (!is_dir('repos')) {


### PR DESCRIPTION
Otherwise errors out saying somethingsomethingtg.conf not found.